### PR TITLE
ボスの討伐率を表示するように

### DIFF
--- a/src/components/statistic.tsx
+++ b/src/components/statistic.tsx
@@ -1,9 +1,7 @@
 import { bossList, gradeList } from '@/lib/splatoon/labels'
 import React from 'react'
-import { CartesianGrid, Line, LineChart, Tooltip, XAxis, YAxis } from 'recharts'
 import { Statistic, Table } from 'semantic-ui-react'
 import dynamic from 'next/dynamic'
-import { cdate } from 'cdate'
 
 const GradePointChart = dynamic(async () => await (await import('./gradePointChart')).GradePointChart, { ssr: false })
 

--- a/src/components/statistic.tsx
+++ b/src/components/statistic.tsx
@@ -43,18 +43,37 @@ export const StatisticViewer = (props: Props) => {
             <Table.Header>
                 <Table.Row>
                     <Table.HeaderCell>種別</Table.HeaderCell>
-                    <Table.HeaderCell>撃破数</Table.HeaderCell>
+                    <Table.HeaderCell>あなたの討伐数</Table.HeaderCell>
+                    <Table.HeaderCell>あなたの討伐率</Table.HeaderCell>
+                    <Table.HeaderCell>なかまの討伐数</Table.HeaderCell>
+                    <Table.HeaderCell>なかまの討伐率</Table.HeaderCell>
                     <Table.HeaderCell>出現数</Table.HeaderCell>
+                    <Table.HeaderCell>討伐率</Table.HeaderCell>
                 </Table.Row>
             </Table.Header>
             <Table.Body>
                 {bossList.map((key, index) => {
                     if (props.statistic.bossCounts[index] === 0) return
+                    const {statistic} = props
+                    const bossCount = statistic.bossCounts[index]
+                    const bossKillCount = statistic.bossKillCounts[index]
+                    const bossKillCountPercentage = Math.floor(bossKillCount/bossCount*100)
+                    const bossKillCountByTeam = statistic.bossKillCountsByTeam[index]
+                    const bossKillCountByTeamPercentage = Math.floor((bossKillCountByTeam-bossKillCount)/3/bossCount*100)
+
                     return (
                     <Table.Row key={key}>
-                        <Table.Cell>{key}</Table.Cell>
-                        <Table.Cell>{props.statistic.bossKillCounts[index]}</Table.Cell>
-                        <Table.Cell>{props.statistic.bossCounts[index]}</Table.Cell>
+                        <Table.Cell content={key} />
+                        <Table.Cell content={bossKillCount} />
+                        <Table.Cell
+                            className={bossKillCountByTeamPercentage <= bossKillCountPercentage? 'text-green' : 'text-red'}
+                            content={`${bossKillCountPercentage}%`} />
+                        <Table.Cell content={bossKillCountByTeam-bossKillCount} />
+                        <Table.Cell
+                            className={bossKillCountByTeamPercentage <= bossKillCountPercentage? 'text-red' : 'text-green'}
+                            content={`${bossKillCountByTeamPercentage}%`} />
+                        <Table.Cell content={bossCount} />
+                        <Table.Cell content={`${Math.floor(bossKillCountByTeam/bossCount*100)}%`} />
                     </Table.Row>)
                 })}
             </Table.Body>

--- a/src/lib/type.d.ts
+++ b/src/lib/type.d.ts
@@ -48,6 +48,7 @@ interface JobResult {
 
 interface Statistic {
     bossKillCounts: number[]
+    bossKillCountsByTeam: number[]
     bossCounts: number[]
     result: {
         playTime: number

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -4,6 +4,7 @@ import { cdate } from 'cdate'
 import { Container, Dropdown, Header, Tab, Table } from 'semantic-ui-react'
 import { bossList, stageList } from '@/lib/splatoon/labels'
 import { StatisticViewer } from '@/components/statistic'
+import { sumArray } from '@/lib/utils'
 
 
 
@@ -51,6 +52,7 @@ export default function Home() {
           tmp.bossKillCounts = tmp.bossKillCounts.map((v: number, index: number) => {
             return v + current.players[0].boss_kill_counts[index]
           })
+          tmp.bossKillCountsByTeam = sumArray(tmp.bossKillCountsByTeam, current.boss_kill_counts)
           previous[key] = tmp
           
           return previous
@@ -58,6 +60,7 @@ export default function Home() {
           get(target: ParseResult, name: string) {
             return name in target ? target[name] : {
               bossKillCounts: Array(15).fill(0),
+              bossKillCountsByTeam: Array(15).fill(0),
               bossCounts: Array(15).fill(0),
               result: [],
             }
@@ -71,15 +74,13 @@ export default function Home() {
 
   const bossCounts = Object.keys(parseResult).reduce((previous, key) => {
     const result = parseResult[key]
-    previous.bossCounts = result.bossCounts.map((v: number, index: number) => {
-      return v + previous.bossCounts[index]
-    })
-    previous.bossKillCounts = result.bossKillCounts.map((v: number, index: number) => {
-      return v + previous.bossKillCounts[index]
-    })
+    previous.bossCounts = sumArray(result.bossCounts, previous.bossCounts)
+    previous.bossKillCounts = sumArray(result.bossKillCounts, previous.bossKillCounts)
+    previous.bossKillCountsByTeam = sumArray(result.bossKillCountsByTeam, previous.bossKillCountsByTeam)
     return previous
   }, {
     bossKillCounts: Array(15).fill(0),
+    bossKillCountsByTeam: Array(15).fill(0),
     bossCounts: Array(15).fill(0),
   })
   

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,0 +1,7 @@
+.text-red {
+    color: #dc3545!important;
+}
+
+.text-green {
+    color: #198754!important;
+}


### PR DESCRIPTION
## 概要

- チームのオオモノシャケ討伐数を計測するように修正
- チームのオオモノシャケ討伐数から自分の討伐数を引いて、自分以外の一人当たりの討伐数と討伐率を可視化
- 自分の討伐数を可視化
- 上記の討伐率が味方を上回っている場合、色をつけて強調表示するようにした

## サンプル

![image](https://user-images.githubusercontent.com/5634646/216083347-7bc9a718-3cc0-424d-84ea-2328bf6accf6.png)
