### PR TITLE
Y軸で表示する情報を追加

### DIFF
--- a/src/components/gradePointChart.tsx
+++ b/src/components/gradePointChart.tsx
@@ -9,6 +9,14 @@ interface Props {
     graphData: {value: number}[],
 }
 
+const extraLabel: {[key: number]: string} = {
+    1000: '200バッジ',
+    1200: '銅バッジ',
+    1400: '銀バッジ',
+    1665: '危険度MAX目安',
+    1799: 'カンスト',
+}
+
 const CustomTooltip = ({active, payload, label}: TooltipProps<ValueType, NameType>) => {
     if (active && payload && payload.length) {
         return <div className="custom-tooltip">
@@ -19,7 +27,8 @@ const CustomTooltip = ({active, payload, label}: TooltipProps<ValueType, NameTyp
     return <></>
 }
 
-const convertRank = (value: any, index: number): string => {
+const convertRank = (value: number, index: number): string => {
+    if (extraLabel[value]) return extraLabel[value]
     const i = (value / 100 | 0)
     return i < gradeList.length ? gradeList[i] : ''
 }
@@ -31,7 +40,7 @@ const convertTime = (playTime: number) => {
 export const GradePointChart = (props: Props) => {
     const min = Math.min(...props.graphData.map(v => v.value)) - 100
     const max = Math.max(...props.graphData.map(v => v.value))
-    const ticks = gradeList.map((v, i) => i * 100).filter(v => v <= max).filter(v => v >= min)
+    const ticks = gradeList.map((v, i) => i * 100).concat(Object.keys(extraLabel).map(Number)).filter(v => v <= max+300).filter(v => v >= min)
     return (
     <>
         <LineChart width={1000} height={500} data={props.graphData} margin={{ top: 5, right: 20, bottom: 5, left: 0 }}>
@@ -47,7 +56,7 @@ export const GradePointChart = (props: Props) => {
             <YAxis
                 width={100}
                 tickFormatter={convertRank}
-                domain={['auto', 'dataMax+50']}
+                domain={['auto', 'auto']}
                 ticks={ticks}
                 textAnchor='end' />
         </LineChart>


### PR DESCRIPTION
## 概要

でんせつ～カンストまでの間には目標となりがちな各種バッジが存在する
ので各種バッジに対応したY軸のラベルとtickを追加する

## サンプル

![image](https://user-images.githubusercontent.com/5634646/219873687-19ef02b8-b790-4797-8997-72c5161ee2a3.png)
